### PR TITLE
Ensure lost cast is detected by monitor

### DIFF
--- a/src/spg.erl
+++ b/src/spg.erl
@@ -259,8 +259,8 @@ handle_cast({discover, Peer}, #state{scope = Scope, nodes = Nodes} = State) ->
         true ->
             {noreply, State};
         false ->
-            gen_server:cast(Peer, {discover, self()}),
             MRef = monitor(process, Peer),
+            gen_server:cast(Peer, {discover, self()}),
             {noreply, State#state{nodes = Nodes#{Peer => {MRef, #{}}}}}
     end;
 


### PR DESCRIPTION
When looking at this isolated:
```
            gen_server:cast(Peer, {discover, self()}),
            MRef = monitor(process, Peer),
```
the discover message might be lost without a DOWN message being delivered. In `spg` the situation might however recover anyway due to the `net_kernel:monitor_nodes()`, but I'm not sure.