### PR TITLE
[spg] Implement group event subscriptions, monitor_scope/demonitor for all groups

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -5,23 +5,27 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, reopened, synchronize]
 
 jobs:
-  test:
-    name: Erlang/OTP ${{matrix.otp}} / rebar3 ${{matrix.rebar3}}
-    runs-on: ubuntu-latest
+  linux:
+    name: Test on OTP ${{ matrix.otp_version }} and ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
-        otp: ['21.3.8.9', '22.3.4.9', '23.3.4.9', '24.3.2', '25.0']
-        rebar3: ['3.17']
+        otp_version: ['21.3.8.9', '22.3.4.9', '23.3.4.9', '24.3.2', '25.0']
+        os: [ubuntu-latest]
+
+    container:
+      image: erlang:${{ matrix.otp_version }}
+
     steps:
       - uses: actions/checkout@v2
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{matrix.otp}}
-          rebar3-version: ${{matrix.rebar3}}
       - name: Compile
         run: rebar3 compile
-      - name: Run tests
+      - name: CT tests
         run: rebar3 do edoc,ct
+      - shell: bash
+        name: Dialyzer
+        run: rebar3 dialyzer

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ['21.3.8.9', '22.3.4.9', '23.3.4.9', '24.3.2']
-        rebar3: ['3.15']
+        otp: ['21.3.8.9', '22.3.4.9', '23.3.4.9', '24.3.2', '25.0']
+        rebar3: ['3.17']
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,35 @@
+stages:
+  - test
+  - deploy
+
+test-default-docker:
+  tags:
+    - linux
+  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/erlang:latest
+  stage: test
+  script:
+    - rebar3 compile
+    - rebar3 edoc
+    - rebar3 dialyzer
+    - rebar3 ct
+  artifacts:
+    when: always
+    paths:
+      - "_build/test/logs/**"
+    expire_in: 3 days
+    reports:
+      junit:
+        - _build/test/logs/last/junit_report.xml
+
+# Pages: publishing Common Test results
+pages:
+  stage: deploy
+  needs:
+    - test-default-docker
+  script:
+    - mv _build/test/logs ./public
+  artifacts:
+    paths:
+      - public
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH

--- a/src/spg.erl
+++ b/src/spg.erl
@@ -121,7 +121,7 @@ leave(Group, PidOrPids) ->
     leave(?DEFAULT_SCOPE, Group, PidOrPids).
 
 -spec leave(Scope :: atom(), Group :: group(), PidOrPids :: pid() | [pid()]) -> ok | not_joined.
-leave(Scope, Group, PidOrPids) ->
+leave(Scope, Group, PidOrPids) when is_pid(PidOrPids); is_list(PidOrPids) ->
     ok = ensure_local(PidOrPids),
     gen_server:call(Scope, {leave_local, Group, PidOrPids}, infinity).
 
@@ -187,9 +187,9 @@ which_local_groups(Scope) when is_atom(Scope) ->
     %% ETS table name, and also the registered process name (self())
     scope :: atom(),
     %% monitored local processes and groups they joined
-    monitors = #{} :: #{pid() => {MRef :: reference(), Groups :: [group()]}},
+    local = #{} :: #{pid() => {MRef :: reference(), Groups :: [group()]}},
     %% remote node: scope process monitor and map of groups to pids for fast sync routine
-    nodes = #{} :: #{pid() => {reference(), #{group() => [pid()]}}}
+    remote = #{} :: #{pid() => {reference(), #{group() => [pid()]}}}
 }).
 
 -type state() :: #state{}.
@@ -197,30 +197,32 @@ which_local_groups(Scope) when is_atom(Scope) ->
 -spec init([Scope :: atom()]) -> {ok, state()}.
 init([Scope]) ->
     ok = net_kernel:monitor_nodes(true),
-    %% discover all nodes in the cluster
+    %% discover all nodes running this scope in the cluster
     broadcast([{Scope, Node} || Node <- nodes()], {discover, self()}),
     Scope = ets:new(Scope, [set, protected, named_table, {read_concurrency, true}]),
     {ok, #state{scope = Scope}}.
 
 -spec handle_call(Call :: {join_local, Group :: group(), Pid :: pid()}
                         | {leave_local, Group :: group(), Pid :: pid()},
-                  From :: {pid(),Tag :: any()},
+                  From :: {pid(), Tag :: any()},
                   State :: state()) -> {reply, ok | not_joined, state()}.
 
-handle_call({join_local, Group, PidOrPids}, _From, #state{scope = Scope, monitors = Monitors, nodes = Nodes} = State) ->
-    NewMons = join_monitors(PidOrPids, Group, Monitors),
-    join_local_group(Scope, Group, PidOrPids),
-    broadcast(maps:keys(Nodes), {join, self(), Group, PidOrPids}),
-    {reply, ok, State#state{monitors = NewMons}};
+handle_call({join_local, Group, PidOrPids}, _From, #state{scope = Scope, local = Local,
+    remote = Remote} = State) ->
+    NewMons = join_local(PidOrPids, Group, Local),
+    join_local_update_ets(Scope, Group, PidOrPids),
+    broadcast(maps:keys(Remote), {join, self(), Group, PidOrPids}),
+    {reply, ok, State#state{local = NewMons}};
 
-handle_call({leave_local, Group, PidOrPids}, _From, #state{scope = Scope, monitors = Monitors, nodes = Nodes} = State) ->
-    case leave_monitors(PidOrPids, Group, Monitors) of
-        Monitors ->
+handle_call({leave_local, Group, PidOrPids}, _From, #state{scope = Scope, local = Local,
+    remote = Remote} = State) ->
+    case leave_local(PidOrPids, Group, Local) of
+        Local ->
             {reply, not_joined, State};
         NewMons ->
-            leave_local_group(Scope, Group, PidOrPids),
-            broadcast(maps:keys(Nodes), {leave, self(), PidOrPids, [Group]}),
-            {reply, ok, State#state{monitors = NewMons}}
+            leave_local_update_ets(Scope, Group, PidOrPids),
+            broadcast(maps:keys(Remote), {leave, self(), PidOrPids, [Group]}),
+            {reply, ok, State#state{local = NewMons}}
     end;
 
 handle_call(_Request, _From, _S) ->
@@ -233,8 +235,8 @@ handle_call(_Request, _From, _S) ->
     {leave, Peer :: pid(), pid() | [pid()], [group()]},
     State :: state()) -> {noreply, state()}.
 
-handle_cast({sync, Peer, Groups}, #state{scope = Scope, nodes = Nodes} = State) ->
-    {noreply, State#state{nodes = handle_sync(Scope, Peer, Nodes, Groups)}};
+handle_cast({sync, Peer, Groups}, #state{scope = Scope, remote = Remote} = State) ->
+    {noreply, State#state{remote = handle_sync(Scope, Peer, Remote, Groups)}};
 
 handle_cast(_, _State) ->
     error(badarg).
@@ -247,13 +249,13 @@ handle_cast(_, _State) ->
     {nodedown, node()} | {nodeup, node()}, State :: state()) -> {noreply, state()}.
 
 %% remote pid or several pids joining the group
-handle_info({join, Peer, Group, PidOrPids}, #state{scope = Scope, nodes = Nodes} = State) ->
-    case maps:get(Peer, Nodes, []) of
+handle_info({join, Peer, Group, PidOrPids}, #state{scope = Scope, remote = Remote} = State) ->
+    case maps:get(Peer, Remote, []) of
         {MRef, RemoteGroups} ->
-            join_remote(Scope, Group, PidOrPids),
+            join_remote_update_ets(Scope, Group, PidOrPids),
             %% store remote group => pids map for fast sync operation
-            NewRemoteGroups = join_remote_map(Group, PidOrPids, RemoteGroups),
-            {noreply, State#state{nodes = Nodes#{Peer => {MRef, NewRemoteGroups}}}};
+            NewRemoteGroups = join_remote(Group, PidOrPids, RemoteGroups),
+            {noreply, State#state{remote = Remote#{Peer => {MRef, NewRemoteGroups}}}};
         [] ->
             %% handle possible race condition, when remote node is flickering up/down,
             %%  and remote join can happen after the node left overlay network
@@ -263,12 +265,12 @@ handle_info({join, Peer, Group, PidOrPids}, #state{scope = Scope, nodes = Nodes}
     end;
 
 %% remote pid leaving (multiple groups at once)
-handle_info({leave, Peer, PidOrPids, Groups}, #state{scope = Scope, nodes = Nodes} = State) ->
-    case maps:get(Peer, Nodes, []) of
+handle_info({leave, Peer, PidOrPids, Groups}, #state{scope = Scope, remote = Remote} = State) ->
+    case maps:get(Peer, Remote, []) of
         {MRef, RemoteMap} ->
-            _ = leave_remote(Scope, PidOrPids, Groups),
-            NewRemoteMap = leave_update_remote_map(PidOrPids, RemoteMap, Groups),
-            {noreply, State#state{nodes = Nodes#{Peer => {MRef, NewRemoteMap}}}};
+            _ = leave_remote_update_ets(Scope, PidOrPids, Groups),
+            NewRemoteMap = leave_remote(PidOrPids, RemoteMap, Groups),
+            {noreply, State#state{remote = Remote#{Peer => {MRef, NewRemoteMap}}}};
         [] ->
             %% Handle race condition: remote node disconnected, but scope process
             %%  of the remote node was just about to send 'leave' message. In this
@@ -280,36 +282,37 @@ handle_info({leave, Peer, PidOrPids, Groups}, #state{scope = Scope, nodes = Node
     end;
 
 %% we're being discovered, let's exchange!
-handle_info({discover, Peer}, #state{monitors = Monitors, nodes = Nodes} = State) ->
-    gen_server:cast(Peer, {sync, self(), all_local_pids(Monitors)}),
+handle_info({discover, Peer}, #state{remote = Remote, local = Local} = State) ->
+    gen_server:cast(Peer, {sync, self(), all_local_pids(Local)}),
     %% do we know who is looking for us?
-    case maps:is_key(Peer, Nodes) of
+    case maps:is_key(Peer, Remote) of
         true ->
             {noreply, State};
         false ->
-            MRef = monitor(process, Peer),
+            MRef = erlang:monitor(process, Peer),
             erlang:send(Peer, {discover, self()}, [noconnect]),
-            {noreply, State#state{nodes = Nodes#{Peer => {MRef, #{}}}}}
+            {noreply, State#state{remote = Remote#{Peer => {MRef, #{}}}}}
     end;
 
 %% handle local process exit
-handle_info({'DOWN', MRef, process, Pid, _Info}, #state{scope = Scope, monitors = Monitors, nodes = Nodes} = State) when node(Pid) =:= node() ->
-    case maps:take(Pid, Monitors) of
+handle_info({'DOWN', MRef, process, Pid, _Info}, #state{scope = Scope, local = Local,
+    remote = Remote} = State) when node(Pid) =:= node() ->
+    case maps:take(Pid, Local) of
         error ->
             %% this can only happen when leave request and 'DOWN' are in pg queue
             {noreply, State};
-        {{MRef, Groups}, NewMons} ->
-            [leave_local_group(Scope, Group, Pid) || Group <- Groups],
-            %% send update to all nodes
-            broadcast(maps:keys(Nodes), {leave, self(), Pid, Groups}),
-            {noreply, State#state{monitors = NewMons}}
+        {{MRef, Groups}, NewLocal} ->
+            [leave_local_update_ets(Scope, Group, Pid) || Group <- Groups],
+            %% send update to all remote peers
+            broadcast(maps:keys(Remote), {leave, self(), Pid, Groups}),
+            {noreply, State#state{local = NewLocal}}
     end;
 
-%% handle remote node down or leaving overlay network
-handle_info({'DOWN', MRef, process, Pid, _Info}, #state{scope = Scope, nodes = Nodes} = State)  ->
-    {{MRef, RemoteMap}, NewNodes} = maps:take(Pid, Nodes),
-    _ = maps:map(fun (Group, Pids) -> leave_remote(Scope, Pids, [Group]) end, RemoteMap),
-    {noreply, State#state{nodes = NewNodes}};
+%% handle remote node down or scope leaving overlay network
+handle_info({'DOWN', MRef, process, Pid, _Info}, #state{scope = Scope, remote = Remote} = State)  ->
+    {{MRef, RemoteMap}, NewRemote} = maps:take(Pid, Remote),
+    maps:foreach(fun (Group, Pids) -> leave_remote_update_ets(Scope, Pids, [Group]) end, RemoteMap),
+    {noreply, State#state{remote = NewRemote}};
 
 %% nodedown: ignore, and wait for 'DOWN' signal for monitored process
 handle_info({nodedown, _Node}, State) ->
@@ -344,29 +347,28 @@ ensure_local(Pids) when is_list(Pids) ->
                 error({nolocal, Bad})
         end, Pids);
 ensure_local(Bad) ->
-    error({nolocal, Bad}).
-
+    erlang:error({nolocal, Bad}).
 
 %% Override all knowledge of the remote node with information it sends
 %%  to local node. Current implementation must do the full table scan
 %%  to remove stale pids (just as for 'nodedown').
-handle_sync(Scope, Peer, Nodes, Groups) ->
+handle_sync(Scope, Peer, Remote, Groups) ->
     %% can't use maps:get() because it evaluates 'default' value first,
     %%   and in this case monitor() call has side effect.
     {MRef, RemoteGroups} =
-        case maps:find(Peer, Nodes) of
+        case maps:find(Peer, Remote) of
             error ->
-                {monitor(process, Peer), #{}};
+                {erlang:monitor(process, Peer), #{}};
             {ok, MRef0} ->
                 MRef0
         end,
     %% sync RemoteMap and transform ETS table
     _ = sync_groups(Scope, RemoteGroups, Groups),
-    Nodes#{Peer => {MRef, maps:from_list(Groups)}}.
+    Remote#{Peer => {MRef, maps:from_list(Groups)}}.
 
 sync_groups(Scope, RemoteGroups, []) ->
     %% leave all missing groups
-    [leave_remote(Scope, Pids, [Group]) || {Group, Pids} <- maps:to_list(RemoteGroups)];
+    [leave_remote_update_ets(Scope, Pids, [Group]) || {Group, Pids} <- maps:to_list(RemoteGroups)];
 sync_groups(Scope, RemoteGroups, [{Group, Pids} | Tail]) ->
     case maps:take(Group, RemoteGroups) of
         {Pids, NewRemoteGroups} ->
@@ -378,31 +380,31 @@ sync_groups(Scope, RemoteGroups, [{Group, Pids} | Tail]) ->
             true = ets:insert(Scope, {Group, AllNewPids, LocalPids}),
             sync_groups(Scope, NewRemoteGroups, Tail);
         error ->
-            join_remote(Scope, Group, Pids),
+            join_remote_update_ets(Scope, Group, Pids),
             sync_groups(Scope, RemoteGroups, Tail)
     end.
 
-join_monitors(Pid, Group, Monitors) when is_pid(Pid) ->
-    case maps:find(Pid, Monitors) of
+join_local(Pid, Group, Local) when is_pid(Pid) ->
+    case maps:find(Pid, Local) of
         {ok, {MRef, Groups}} ->
-            maps:put(Pid, {MRef, [Group | Groups]}, Monitors);
+            maps:put(Pid, {MRef, [Group | Groups]}, Local);
         error ->
             MRef = erlang:monitor(process, Pid),
-            Monitors#{Pid => {MRef, [Group]}}
+            Local#{Pid => {MRef, [Group]}}
     end;
-join_monitors([], _Group, Monitors) ->
-    Monitors;
-join_monitors([Pid | Tail], Group, Monitors) ->
-    join_monitors(Tail, Group, join_monitors(Pid, Group, Monitors)).
+join_local([], _Group, Local) ->
+    Local;
+join_local([Pid | Tail], Group, Local) ->
+    join_local(Tail, Group, join_local(Pid, Group, Local)).
 
-join_local_group(Scope, Group, Pid) when is_pid(Pid) ->
+join_local_update_ets(Scope, Group, Pid) when is_pid(Pid) ->
     case ets:lookup(Scope, Group) of
         [{Group, All, Local}] ->
             ets:insert(Scope, {Group, [Pid | All], [Pid | Local]});
         [] ->
             ets:insert(Scope, {Group, [Pid], [Pid]})
     end;
-join_local_group(Scope, Group, Pids) ->
+join_local_update_ets(Scope, Group, Pids) ->
     case ets:lookup(Scope, Group) of
         [{Group, All, Local}] ->
             ets:insert(Scope, {Group, Pids ++ All, Pids ++ Local});
@@ -410,14 +412,14 @@ join_local_group(Scope, Group, Pids) ->
             ets:insert(Scope, {Group, Pids, Pids})
     end.
 
-join_remote(Scope, Group, Pid) when is_pid(Pid) ->
+join_remote_update_ets(Scope,  Group, Pid) when is_pid(Pid) ->
     case ets:lookup(Scope, Group) of
         [{Group, All, Local}] ->
             ets:insert(Scope, {Group, [Pid | All], Local});
         [] ->
             ets:insert(Scope, {Group, [Pid], []})
     end;
-join_remote(Scope, Group, Pids) ->
+join_remote_update_ets(Scope, Group, Pids) ->
     case ets:lookup(Scope, Group) of
         [{Group, All, Local}] ->
             ets:insert(Scope, {Group, Pids ++ All, Local});
@@ -425,32 +427,32 @@ join_remote(Scope, Group, Pids) ->
             ets:insert(Scope, {Group, Pids, []})
     end.
 
-join_remote_map(Group, Pid, RemoteGroups) when is_pid(Pid) ->
+join_remote(Group, Pid, RemoteGroups) when is_pid(Pid) ->
     maps:update_with(Group, fun (List) -> [Pid | List] end, [Pid], RemoteGroups);
-join_remote_map(Group, Pids, RemoteGroups) ->
+join_remote(Group, Pids, RemoteGroups) ->
     maps:update_with(Group, fun (List) -> Pids ++ List end, Pids, RemoteGroups).
 
-leave_monitors(Pid, Group, Monitors) when is_pid(Pid) ->
-    case maps:find(Pid, Monitors) of
+leave_local(Pid, Group, Local) when is_pid(Pid) ->
+    case maps:find(Pid, Local) of
         {ok, {MRef, [Group]}} ->
             erlang:demonitor(MRef),
-            maps:remove(Pid, Monitors);
+            maps:remove(Pid, Local);
         {ok, {MRef, Groups}} ->
             case lists:member(Group, Groups) of
                 true ->
-                    maps:put(Pid, {MRef, lists:delete(Group, Groups)}, Monitors);
+                    maps:put(Pid, {MRef, lists:delete(Group, Groups)}, Local);
                 false ->
-                    Monitors
+                    Local
             end;
         _ ->
-            Monitors
+            Local
     end;
-leave_monitors([], _Group, Monitors) ->
-    Monitors;
-leave_monitors([Pid | Tail], Group, Monitors) ->
-    leave_monitors(Tail, Group, leave_monitors(Pid, Group, Monitors)).
+leave_local([], _Group, Local) ->
+    Local;
+leave_local([Pid | Tail], Group, Local) ->
+    leave_local(Tail, Group, leave_local(Pid, Group, Local)).
 
-leave_local_group(Scope, Group, Pid) when is_pid(Pid) ->
+leave_local_update_ets(Scope, Group, Pid) when is_pid(Pid) ->
     case ets:lookup(Scope, Group) of
         [{Group, [Pid], [Pid]}] ->
             ets:delete(Scope, Group);
@@ -460,7 +462,7 @@ leave_local_group(Scope, Group, Pid) when is_pid(Pid) ->
             %% rare race condition when 'DOWN' from monitor stays in msg queue while process is leave-ing.
             true
     end;
-leave_local_group(Scope, Group, Pids) ->
+leave_local_update_ets(Scope, Group, Pids) ->
     case ets:lookup(Scope, Group) of
         [{Group, All, Local}] ->
             case All -- Pids of
@@ -473,7 +475,7 @@ leave_local_group(Scope, Group, Pids) ->
             true
     end.
 
-leave_remote(Scope, Pid, Groups) when is_pid(Pid) ->
+leave_remote_update_ets(Scope, Pid, Groups) when is_pid(Pid) ->
     _ = [
         case ets:lookup(Scope, Group) of
             [{Group, [Pid], []}] ->
@@ -484,7 +486,7 @@ leave_remote(Scope, Pid, Groups) when is_pid(Pid) ->
                 true
         end ||
         Group <- Groups];
-leave_remote(Scope, Pids, Groups) ->
+leave_remote_update_ets(Scope, Pids, Groups) ->
     _ = [
         case ets:lookup(Scope, Group) of
             [{Group, All, Local}] ->
@@ -499,33 +501,27 @@ leave_remote(Scope, Pids, Groups) ->
         end ||
         Group <- Groups].
 
-leave_update_remote_map(Pid, RemoteMap, Groups) when is_pid(Pid) ->
-    leave_update_remote_map([Pid], RemoteMap, Groups);
-leave_update_remote_map(Pids, RemoteMap, Groups) ->
+leave_remote(Pid, RemoteMap, Groups) when is_pid(Pid) ->
+    leave_remote([Pid], RemoteMap, Groups);
+leave_remote(Pids, RemoteMap, Groups) ->
     lists:foldl(
         fun (Group, Acc) ->
             case maps:get(Group, Acc) -- Pids of
                 [] ->
                     maps:remove(Group, Acc);
-                Existing ->
-                    Acc#{Group => Existing}
+                Remaining ->
+                    Acc#{Group => Remaining}
             end
         end, RemoteMap, Groups).
 
-all_local_pids(Monitors) ->
+all_local_pids(Local) ->
     maps:to_list(maps:fold(
         fun(Pid, {_Ref, Groups}, Acc) ->
             lists:foldl(
                 fun(Group, Acc1) ->
                     Acc1#{Group => [Pid | maps:get(Group, Acc1, [])]}
-                end,
-                Acc,
-                Groups
-            )
-        end,
-        #{},
-        Monitors
-    )).
+                end, Acc, Groups)
+        end, #{}, Local)).
 
 %% Works as gen_server:abcast(), but accepts a list of processes
 %%   instead of nodes list.

--- a/test/spg_SUITE.erl
+++ b/test/spg_SUITE.erl
@@ -40,7 +40,8 @@
     missing_scope_join/1,
     disconnected_start/1,
     forced_sync/0, forced_sync/1,
-    group_leave/1
+    group_leave/1,
+    monitor_all/0, monitor_all/1
 ]).
 
 -export([
@@ -89,7 +90,7 @@ end_per_testcase(TestCase, _Config) ->
     ok.
 
 all() ->
-    [app, dyn_distribution, {group, basic}, {group, cluster}, {group, performance}].
+    [app, dyn_distribution, {group, basic}, {group, cluster}, {group, performance}, {group, monitor}].
 
 groups() ->
     [
@@ -97,7 +98,8 @@ groups() ->
         {performance, [sequential], [thundering_herd]},
         {cluster, [parallel], [two, initial, netsplit, trisplit, foursplit,
             exchange, nolocal, double, scope_restart, missing_scope_join, empty_group_by_remote_leave,
-            disconnected_start, forced_sync, group_leave]}
+            disconnected_start, forced_sync, group_leave]},
+        {monitor, [parallel], [monitor_all]}
     ].
 
 %%--------------------------------------------------------------------
@@ -288,18 +290,19 @@ empty_group_by_remote_leave(Config) when is_list(Config) ->
     {TwoPeer, Socket} = spawn_node(?FUNCTION_NAME, ?FUNCTION_NAME),
     RemoteNode = rpc:call(TwoPeer, erlang, whereis, [?FUNCTION_NAME]),
     RemotePid = erlang:spawn(TwoPeer, forever()),
-    % remote join
+    %% remote join
     ?assertEqual(ok, rpc:call(TwoPeer, spg, join, [?FUNCTION_NAME, ?FUNCTION_NAME, RemotePid])),
     sync({?FUNCTION_NAME, TwoPeer}),
     ?assertEqual([RemotePid], spg:get_members(?FUNCTION_NAME, ?FUNCTION_NAME)),
-    % inspecting internal state is not best practice, but there's no other way to check if the state is correct.
-    {state, _, _, #{RemoteNode := {_, RemoteMap}}} = sys:get_state(?FUNCTION_NAME),
+    %% WHITE BOX: inspecting internal state is not best practice, but there's no other way to check if the state is correct.
+    {state, _, _, #{RemoteNode := {_, RemoteMap}}, _} = sys:get_state(?FUNCTION_NAME),
     ?assertEqual(#{?FUNCTION_NAME => [RemotePid]}, RemoteMap),
-    % remote leave
+    %% remote leave
     ?assertEqual(ok, rpc:call(TwoPeer, spg, leave, [?FUNCTION_NAME, ?FUNCTION_NAME, RemotePid])),
     sync({?FUNCTION_NAME, TwoPeer}),
+    %% WHITE BOX
     ?assertEqual([], spg:get_members(?FUNCTION_NAME, ?FUNCTION_NAME)),
-        {state, _, _, #{RemoteNode := {_, NewRemoteMap}}} = sys:get_state(?FUNCTION_NAME),
+        {state, _, _, #{RemoteNode := {_, NewRemoteMap}}, _} = sys:get_state(?FUNCTION_NAME),
     % empty group should be deleted.
     ?assertEqual(#{}, NewRemoteMap),
 
@@ -312,7 +315,8 @@ empty_group_by_remote_leave(Config) when is_list(Config) ->
     ?assertEqual(ok, rpc:call(TwoPeer, spg, leave, [?FUNCTION_NAME, ?FUNCTION_NAME, [RemotePid2, RemotePid]])),
     sync({?FUNCTION_NAME, TwoPeer}),
     ?assertEqual([], spg:get_members(?FUNCTION_NAME, ?FUNCTION_NAME)),
-    {state, _, _, #{RemoteNode := {_, NewRemoteMap}}} = sys:get_state(?FUNCTION_NAME),
+    %% WHITE BOX
+    {state, _, _, #{RemoteNode := {_, NewRemoteMap}}, _} = sys:get_state(?FUNCTION_NAME),
     stop_node(TwoPeer, Socket),
     ok.
 
@@ -592,6 +596,86 @@ group_leave(Config) when is_list(Config) ->
     sync(?FUNCTION_NAME),
     ?assertEqual([], spg:get_members(?FUNCTION_NAME, two)),
     ok.
+
+monitor_all() ->
+    [{doc, "Tests monitor/1 and demonitor/2"}].
+
+monitor_all(Config) when is_list(Config) ->
+    Self = self(),
+    Scope = ?FUNCTION_NAME,
+    Group = ?FUNCTION_ARITY,
+    %% ensure that demonitoring returns 'false' when monitor is not installed
+    ?assertEqual(false, spg:demonitor(Scope, erlang:make_ref())),
+    %% start the actual test case
+    {Ref, #{}} = spg:monitor(Scope),
+    %% local join
+    ?assertEqual(ok, spg:join(Scope, Group, Self)),
+    wait_message(Ref, join, Group, [Self], "Local"),
+    %% start second monitor (which has 1 local pid at the start)
+    SecondMonitor = spawn_link(fun() -> second_monitor(Scope, Group, Self) end),
+    Ref2 = receive {second, SecondRef} -> SecondRef end,
+    %% start a remote node, and a remote monitor
+    {Peer, Socket} = spawn_node(Scope, ?FUNCTION_NAME),
+    ScopePid = whereis(Scope),
+    %% do not care about the remote monitor, it is started only to check DOWN handling
+    _ThirdMonitor = spawn(Peer, fun() -> second_monitor(ScopePid, Group, Self) end),
+    %% remote join
+    RemotePid = erlang:spawn(Peer, forever()),
+    ?assertEqual(ok, rpc:call(Peer, spg, join, [Scope, Group, [RemotePid, RemotePid]])),
+    wait_message(Ref, join, Group, [RemotePid, RemotePid], "Remote"),
+    %% verify leave event
+    ?assertEqual([Self], spg:get_local_members(Scope, Group)),
+    ?assertEqual(ok, spg:leave(Scope, Group, self())),
+    wait_message(Ref, leave, Group, [Self], "Local"),
+    %% remote leave
+    ?assertEqual(ok, rpc:call(Peer, spg, leave, [Scope, Group, RemotePid])),
+    wait_message(Ref, leave, Group, [RemotePid], "Remote"),
+    %% drop the SecondMonitor - this keeps original and remote monitors
+    SecondMonMsgs = gen_server:call(SecondMonitor, flush),
+    %% inspect the queue, it should contain double remote join, then single local and single remove leave
+    ?assertEqual([
+        {Ref2, join, Group, [RemotePid, RemotePid]},
+        {Ref2, leave, Group, [Self]},
+        {Ref2, leave, Group, [RemotePid]}],
+        SecondMonMsgs),
+    %% remote leave via stop (causes remote monitor to go DOWN)
+    stop_node(Peer, Socket),
+    wait_message(Ref, leave, Group, [RemotePid], "Remote stop"),
+    %% WHITE BOX: knowing pg state internals - only the original monitor should stay
+    {state, _, _, _, InternalMonitors} = sys:get_state(?FUNCTION_NAME),
+    ?assertEqual(#{Ref => Self}, InternalMonitors, "pg did not remove DOWNed monitor"),
+    %% demonitor
+    ?assertEqual(ok, spg:demonitor(Scope, Ref)),
+    ?assertEqual(false, spg:demonitor(Scope, Ref)),
+    %% ensure messages don't come
+    ?assertEqual(ok, spg:join(Scope, Group, Self)),
+    sync(Scope),
+    %% join should not be here
+    receive {Ref, Action, Group, [Self]} -> ?assert(false, lists:concat(["Unexpected ", Action, "event"]))
+    after 0 -> ok end.
+
+wait_message(Ref, Action, Group, Pids, Msg) ->
+    receive
+        {Ref, Action, Group, Pids} ->
+            ok
+    after 1000 ->
+        {messages, Msgs} = process_info(self(), messages),
+        ct:pal("Message queue: ~0p", [Msgs]),
+        ?assert(false, Msg ++ " " ++ atom_to_list(Action) ++ " event failed to occur")
+    end.
+
+second_monitor(Scope, Group, Control) ->
+    {Ref, #{Group := [Control]}} = spg:monitor(Scope),
+    Control ! {second, Ref},
+    second_monitor([]).
+
+second_monitor(Msgs) ->
+    receive
+        {'$gen_call', Reply, flush} ->
+            gen:reply(Reply, lists:reverse(Msgs));
+        Msg ->
+            second_monitor([Msg | Msgs])
+    end.
 
 %%--------------------------------------------------------------------
 %% Test Helpers - start/stop additional Erlang nodes


### PR DESCRIPTION
[spg] Implement group event subscriptions,  monitor_scope/demonitor for all groups

Add monitor/0,1 that returns current state, and starts
monitoring for all updates of the scope.
Add demonitor/2 that stops monitoring for the specified
scope and monitor reference.

Readability improvements for spg:
 - renames 'monitors' to 'local' - meaning, processes running on the local node
 - renames 'nodes' to 'remote' for consistency with 'local'
 - makes naming for join/leave updating server state and ETS table consistent